### PR TITLE
Add GetBestSellingProducts feature with unit tests and UI

### DIFF
--- a/Grocery.App/Views/BestSellingProductsView.xaml
+++ b/Grocery.App/Views/BestSellingProductsView.xaml
@@ -24,8 +24,15 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="*"/>
+                        <ColumnDefinition />
                     </Grid.ColumnDefinitions>
                     <!-- PLaats hier de header velden voor de tabel-->
+                    
+                    <Label Text="#" Grid.Column="0" FontAttributes="Bold" />
+                    <Label Text="Product" Grid.Column="1" FontAttributes="Bold" />
+                    <Label Text="Stock" Grid.Column="2" FontAttributes="Bold" />
+                    <Label Text="Verkocht" Grid.Column="3" FontAttributes="Bold" />
+                    <Label Text="Ranking" Grid.Column="4" FontAttributes="Bold" />
                 </Grid>
             </CollectionView.Header>
             <CollectionView.ItemTemplate>
@@ -36,8 +43,14 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="*"/>
+                            <ColumnDefinition />
                         </Grid.ColumnDefinitions>
                         <!-- PLaats hier de datavelden voor de tabel-->
+                        <Label Text="{Binding Id}" Grid.Column="0" />
+                        <Label Text="{Binding Name}" Grid.Column="1" />
+                        <Label Text="{Binding Stock}" Grid.Column="2" />
+                        <Label Text="{Binding NrOfSells}" Grid.Column="3" />
+                        <Label Text="{Binding Ranking}" Grid.Column="4" />
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/TestCore/Builders/GroceryListItemBuilder.cs
+++ b/TestCore/Builders/GroceryListItemBuilder.cs
@@ -1,0 +1,54 @@
+﻿using Grocery.Core.Models;
+
+namespace TestCore.Builders;
+
+public class GroceryListItemBuilder
+{
+    private int _id = 1;
+    private int _productId = 1;
+    private int _userId = 1;
+    private int _listId = 1;
+
+    public GroceryListItemBuilder WithId(int id)
+    {
+        _id = id;
+        return this;
+    }
+
+    public GroceryListItemBuilder WithProductId(int productId)
+    {
+        _productId = productId;
+        return this;
+    }
+
+    public GroceryListItemBuilder WithUserId(int userId)
+    {
+        _userId = userId;
+        return this;
+    }
+
+    public GroceryListItemBuilder WithListId(int listId)
+    {
+        _listId = listId;
+        return this;
+    }
+
+    public GroceryListItem Build()
+    {
+        return new GroceryListItem(_id, _productId, _userId, _listId);
+    }
+
+    public static List<GroceryListItem> CreateMany(params (int productId, int count)[] products)
+    {
+        var items = new List<GroceryListItem>();
+        var id = 1;
+        foreach (var (productId, count) in products)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                items.Add(new GroceryListItem(id++, 1,productId, 100));
+            }
+        }
+        return items;
+    }
+}

--- a/TestCore/GetBestSellingProducts.Tests.cs
+++ b/TestCore/GetBestSellingProducts.Tests.cs
@@ -1,0 +1,296 @@
+﻿using Grocery.Core.Interfaces.Repositories;
+using Grocery.Core.Models;
+using Grocery.Core.Services;
+using Moq;
+using Spectre.Console;
+using TestCore.Builders;
+
+namespace TestCore;
+
+[TestFixture]
+public class GetBestSellingProductsTests
+{
+    [SetUp]
+    public void Setup()
+    {
+    }
+
+    [Test]
+    public void UC11_FR1_GetBestSellingProducts_ShouldReturnTop5Products()
+    {
+        // Arrange
+        var groceries = GroceryListItemBuilder.CreateMany(
+            (1,2),
+            (2,1),
+            (3,3),
+            (4,1),
+            (5,2),
+            (6,1)
+        );
+        
+
+        var groceriesRepoMock = new Mock<IGroceryListItemsRepository>();
+        groceriesRepoMock.Setup(r => r.GetAll()).Returns(groceries);
+
+        var productRepoMock = new Mock<IProductRepository>();
+        productRepoMock.Setup(r => r.Get(It.IsAny<int>()))
+            .Returns<int>(id => new Product(id, $"product{id}", 10));
+
+        var service = new GroceryListItemsService(groceriesRepoMock.Object, productRepoMock.Object);
+
+        // Act
+        var result = service.GetBestSellingProducts();
+
+        // Debug output in een mooie tabel
+        var table = new Table().RoundedBorder();
+        table.AddColumn("Rank");
+        table.AddColumn("Product");
+        table.AddColumn("Stock");
+        table.AddColumn("Verkocht");
+
+        foreach (var p in result)
+        {
+            table.AddRow(p.Ranking.ToString(), p.Name, p.Stock.ToString(), p.NrOfSells.ToString());
+        }
+
+        AnsiConsole.Write(table);
+
+        // Assert
+        Assert.That(result, Has.Count.EqualTo(5));
+        Assert.That(result[0].NrOfSells, Is.EqualTo(3));
+    }
+    
+    [Test]
+    public void UC11_FR1_ShouldReturnEmptyList_WhenNoProducts()
+    {
+        // Arrange
+        var groceriesRepoMock = new Mock<IGroceryListItemsRepository>();
+        groceriesRepoMock.Setup(r => r.GetAll()).Returns(new List<GroceryListItem>());
+        var productRepoMock = new Mock<IProductRepository>();
+
+        var service = new GroceryListItemsService(groceriesRepoMock.Object, productRepoMock.Object);
+
+        // Act
+        var result = service.GetBestSellingProducts();
+        
+        // Debug output in een mooie tabel
+        var table = new Table().RoundedBorder();
+        table.AddColumn("Rank");
+        table.AddColumn("Product");
+        table.AddColumn("Stock");
+        table.AddColumn("Verkocht");
+
+        foreach (var p in result)
+        {
+            table.AddRow(p.Ranking.ToString(), p.Name, p.Stock.ToString(), p.NrOfSells.ToString());
+        }
+
+        AnsiConsole.Write(table);
+
+        // Assert
+        Assert.That(result, Is.Empty);
+    }
+    
+    [Test]
+    public void UC11_FR1_ShouldReturnAll_WhenLessThan5Products()
+    {
+        // Arrange
+        var groceries = GroceryListItemBuilder.CreateMany((1,1),(2,1),(3,1));
+        var groceriesRepoMock = new Mock<IGroceryListItemsRepository>();
+        groceriesRepoMock.Setup(r => r.GetAll()).Returns(groceries);
+
+        var productRepoMock = new Mock<IProductRepository>();
+        productRepoMock.Setup(r => r.Get(It.IsAny<int>())).Returns<int>(id => new Product(id, $"Product{id}", 5));
+
+        var service = new GroceryListItemsService(groceriesRepoMock.Object, productRepoMock.Object);
+
+        // Act
+        var result = service.GetBestSellingProducts();
+        
+        // Debug output in een mooie tabel
+        var table = new Table().RoundedBorder();
+        table.AddColumn("Rank");
+        table.AddColumn("Product");
+        table.AddColumn("Stock");
+        table.AddColumn("Verkocht");
+
+        foreach (var p in result)
+        {
+            table.AddRow(p.Ranking.ToString(), p.Name, p.Stock.ToString(), p.NrOfSells.ToString());
+        }
+
+        AnsiConsole.Write(table);
+
+        // Assert
+        Assert.That(result, Has.Count.EqualTo(3));
+    }
+
+
+
+    [Test]
+    public void UC11_FR2_GetBestSellingProducts_ShouldReturnCorrectProductInfo()
+    {
+        // Arrange
+        var groceries = GroceryListItemBuilder.CreateMany(
+            (1, 2)
+        );
+
+        var groceriesRepoMock = new Mock<IGroceryListItemsRepository>();
+        groceriesRepoMock.Setup(r => r.GetAll()).Returns(groceries);
+
+        var productRepoMock = new Mock<IProductRepository>();
+        productRepoMock.Setup(r => r.Get(1)).Returns(new Product(1, "Banaan", 10));
+
+        var service = new GroceryListItemsService(groceriesRepoMock.Object, productRepoMock.Object);
+
+        // Act
+        var result = service.GetBestSellingProducts();
+        
+        // Debug output in een mooie tabel
+        var table = new Table().RoundedBorder();
+        table.AddColumn("Rank");
+        table.AddColumn("Product");
+        table.AddColumn("Stock");
+        table.AddColumn("Verkocht");
+
+        foreach (var p in result)
+        {
+            table.AddRow(p.Ranking.ToString(), p.Name, p.Stock.ToString(), p.NrOfSells.ToString());
+        }
+
+        AnsiConsole.Write(table);
+
+        // Assert
+        var product = result.First();
+        Assert.Multiple(() =>
+        {
+            Assert.That(product.Id, Is.EqualTo(1));
+            Assert.That(product.Name, Is.EqualTo("Banaan"));
+            Assert.That(product.Stock, Is.EqualTo(10));
+            Assert.That(product.NrOfSells, Is.EqualTo(2));
+            Assert.That(product.Ranking, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void UC11_FR3_AddingProduct_ShouldUpdateBoodschappenlijst()
+    {
+        // Arrange
+        var groceries = new List<GroceryListItem>();
+        var groceriesRepoMock = new Mock<IGroceryListItemsRepository>();
+        groceriesRepoMock.Setup(r => r.GetAll()).Returns(groceries);
+
+        var productRepoMock = new Mock<IProductRepository>();
+        productRepoMock.Setup(r => r.Get(It.IsAny<int>()))
+            .Returns<int>(id => new Product(id, $"Product{id}", 5));
+
+        var service = new GroceryListItemsService(groceriesRepoMock.Object, productRepoMock.Object);
+
+        // Act: nieuw product toevoegen
+        groceries.Add(new GroceryListItem(1, 1, 1, 100));
+        groceries.Add(new GroceryListItem(2, 1, 1, 100));
+
+        var result = service.GetBestSellingProducts();
+        
+        // Debug output in een mooie tabel
+        var table = new Table().RoundedBorder();
+        table.AddColumn("Rank");
+        table.AddColumn("Product");
+        table.AddColumn("Stock");
+        table.AddColumn("Verkocht");
+
+        foreach (var p in result)
+        {
+            table.AddRow(p.Ranking.ToString(), p.Name, p.Stock.ToString(), p.NrOfSells.ToString());
+        }
+
+        AnsiConsole.Write(table);
+
+        // Assert
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].NrOfSells, Is.EqualTo(2));
+    }
+    
+    [Test]
+    public void UC11_FR3_ShouldAccumulateSells_ForSameProduct()
+    {
+        // Arrange
+        var groceries = GroceryListItemBuilder.CreateMany((1,1),(1,1),(1,1)); // 3x zelfde product
+        var groceriesRepoMock = new Mock<IGroceryListItemsRepository>();
+        groceriesRepoMock.Setup(r => r.GetAll()).Returns(groceries);
+
+        var productRepoMock = new Mock<IProductRepository>();
+        productRepoMock.Setup(r => r.Get(1)).Returns(new Product(1,"Appel",10));
+
+        var service = new GroceryListItemsService(groceriesRepoMock.Object, productRepoMock.Object);
+
+        // Act
+        var result = service.GetBestSellingProducts();
+        
+        // Debug output in een mooie tabel
+        var table = new Table().RoundedBorder();
+        table.AddColumn("Rank");
+        table.AddColumn("Product");
+        table.AddColumn("Stock");
+        table.AddColumn("Verkocht");
+
+        foreach (var p in result)
+        {
+            table.AddRow(p.Ranking.ToString(), p.Name, p.Stock.ToString(), p.NrOfSells.ToString());
+        }
+
+        AnsiConsole.Write(table);
+
+        // Assert
+        Assert.That(result[0].NrOfSells, Is.EqualTo(3));
+    }
+
+
+    [Test]
+    public void UC11_NFR2_GetBestSellingProducts_ShouldBeSortedByNrOfSellsDescending()
+    {
+        // Arrange
+        var groceries = new List<GroceryListItem>
+        {
+            new(1, 1, 1, 100),
+            new(2, 1, 1, 100), // 2x
+        
+            new(3, 2, 2, 100), // 1x
+        
+            new(4, 3, 3, 100),
+            new(5, 3, 3, 100),
+            new(6, 3, 3, 100)  // 3x
+        };
+
+        var groceriesRepoMock = new Mock<IGroceryListItemsRepository>();
+        groceriesRepoMock.Setup(r => r.GetAll()).Returns(groceries);
+
+        var productRepoMock = new Mock<IProductRepository>();
+        productRepoMock.Setup(r => r.Get(It.IsAny<int>()))
+            .Returns<int>(id => new Product(id, $"Product{id}", 5));
+
+        var service = new GroceryListItemsService(groceriesRepoMock.Object, productRepoMock.Object);
+
+        // Act
+        var result = service.GetBestSellingProducts();
+        
+        // Debug output in een mooie tabel
+        var table = new Table().RoundedBorder();
+        table.AddColumn("Rank");
+        table.AddColumn("Product");
+        table.AddColumn("Stock");
+        table.AddColumn("Verkocht");
+
+        foreach (var p in result)
+        {
+            table.AddRow(p.Ranking.ToString(), p.Name, p.Stock.ToString(), p.NrOfSells.ToString());
+        }
+
+        AnsiConsole.Write(table);
+
+        // Assert
+        Assert.That(result[0].Id, Is.EqualTo(3)); // meest verkocht
+        Assert.That(result[1].Id, Is.EqualTo(1)); // tweede
+        Assert.That(result[2].Id, Is.EqualTo(2)); // derde
+    }
+}

--- a/TestCore/TestCore.csproj
+++ b/TestCore/TestCore.csproj
@@ -12,9 +12,11 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Spectre.Console" Version="0.51.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Implemented GetBestSellingProducts in GroceryListItemsService
  - Returns top X best-selling products with ranking, stock, and sold count
  - Default topX = 5
- Added GroceryListItemBuilder for test data creation
- Created comprehensive unit tests:
  - Happy path: returns top 5 products
  - Edge cases: empty list, fewer than 5 products
  - Correct product info validation
  - Accumulation of sales for same product
  - Sorting by number of sells
- Updated BestSellingProductsView UI:
  - CollectionView displays Rank, Product, Stock, Sold, and Ranking
  - Header and item template for proper table layout