### PR TITLE
Hotfix aanpassen product aantal

### DIFF
--- a/Grocery.App/ViewModels/BoughtProductsViewModel.cs
+++ b/Grocery.App/ViewModels/BoughtProductsViewModel.cs
@@ -24,6 +24,23 @@ namespace Grocery.App.ViewModels
 
         partial void OnSelectedProductChanged(Product? oldValue, Product newValue)
         {
+            if (newValue == null)
+            {
+                BoughtProductsList.Clear();
+                return;
+            }
+
+            // Haal alle gekocht-producten voor het geselecteerde product
+            var boughtProducts = _boughtProductsService.GetAll()
+                .Where(bp => bp.Product.Id == newValue.Id)
+                .ToList();
+
+            // Update de ObservableCollection
+            BoughtProductsList.Clear();
+            foreach (var bp in boughtProducts)
+            {
+                BoughtProductsList.Add(bp);
+            }
             //Zorg dat de lijst BoughtProductsList met de gegevens die passen bij het geselecteerde product. 
         }
 

--- a/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
@@ -22,8 +22,12 @@ namespace Grocery.App.ViewModels
 
         [ObservableProperty]
         GroceryList groceryList = new(0, "None", DateOnly.MinValue, "", 0);
+        
         [ObservableProperty]
         string myMessage;
+
+        [ObservableProperty] 
+        private int amount;
 
         public GroceryListItemsViewModel(IGroceryListItemsService groceryListItemsService, IProductService productService, IFileSaverService fileSaverService)
         {

--- a/Grocery.App/Views/GroceryListItemsView.xaml
+++ b/Grocery.App/Views/GroceryListItemsView.xaml
@@ -35,24 +35,25 @@
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="4*"/>
                                 <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="20"/>
-                                <ColumnDefinition Width="20"/>
+                                <ColumnDefinition Width="40"/>
+                                <ColumnDefinition Width="40"/>
                             </Grid.ColumnDefinitions>
-                            <Label Grid.Column="0" Text="{Binding Product.Name}" VerticalOptions="Center"/>
-                            <Label Grid.Column="1" Text="{Binding Amount}" VerticalOptions="Center" HorizontalOptions="End" Margin="0,0,10,0"/>
+                            <Label Grid.Column="0" Text="{Binding Product.Name}" VerticalOptions="Center" x:DataType="m:BoughtProducts" />
+                            <Label Grid.Column="1" Text="{Binding Amount}" VerticalOptions="Center" HorizontalOptions="End" Margin="0,0,10,0"
+                                   x:DataType="m:GroceryListItem" />
                             <Grid Grid.Column="2">
                                 <ImageButton Source="plus.png" 
                                              WidthRequest="15" 
                                              HeightRequest="15"
-                                             Command="{Binding IncreaseAmount}"
-                                             CommandParameter="{Binding .}"/>
+                                             Command="{Binding Source={RelativeSource AncestorType={x:Type vm:GroceryListItemsViewModel}}, Path=IncreaseAmountCommand}"
+                                             CommandParameter="{Binding ProductId}" />
                             </Grid>
                             <Grid Grid.Column="3">
                                 <ImageButton Source="min.png" 
                                              WidthRequest="15" 
                                              HeightRequest="15"
-                                             Command="{Binding DecreaseAmount}"
-                                             CommandParameter="{Binding .}"/>
+                                             Command="{Binding Source={RelativeSource AncestorType={x:Type vm:GroceryListItemsViewModel}}, Path=DecreaseAmountCommand}"
+                                             CommandParameter="{Binding ProductId}" />
                             </Grid>
                         </Grid>
                     </DataTemplate>

--- a/Grocery.App/Views/GroceryListItemsView.xaml
+++ b/Grocery.App/Views/GroceryListItemsView.xaml
@@ -41,10 +41,18 @@
                             <Label Grid.Column="0" Text="{Binding Product.Name}" VerticalOptions="Center"/>
                             <Label Grid.Column="1" Text="{Binding Amount}" VerticalOptions="Center" HorizontalOptions="End" Margin="0,0,10,0"/>
                             <Grid Grid.Column="2">
-                                <Image Source="plus.png" WidthRequest="15" HeightRequest="15"/>
+                                <ImageButton Source="plus.png" 
+                                             WidthRequest="15" 
+                                             HeightRequest="15"
+                                             Command="{Binding IncreaseAmount}"
+                                             CommandParameter="{Binding .}"/>
                             </Grid>
                             <Grid Grid.Column="3">
-                                <Image Source="min.png" WidthRequest="15" HeightRequest="15"/>
+                                <ImageButton Source="min.png" 
+                                             WidthRequest="15" 
+                                             HeightRequest="15"
+                                             Command="{Binding DecreaseAmount}"
+                                             CommandParameter="{Binding .}"/>
                             </Grid>
                         </Grid>
                     </DataTemplate>

--- a/Grocery.Core/Interfaces/Services/IBoughtProductsService.cs
+++ b/Grocery.Core/Interfaces/Services/IBoughtProductsService.cs
@@ -6,5 +6,7 @@ namespace Grocery.Core.Interfaces.Services
     public interface IBoughtProductsService
     {
         public List<BoughtProducts> Get(int? productId);
+        
+        public List<BoughtProducts> GetAll(int? productId = null);
     }
 }

--- a/Grocery.Core/Services/BoughtProductsService.cs
+++ b/Grocery.Core/Services/BoughtProductsService.cs
@@ -22,5 +22,33 @@ namespace Grocery.Core.Services
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Haalt alle gekochte producten op, eventueel gefilterd op productId
+        /// </summary>
+        public List<BoughtProducts> GetAll(int? productId = null)
+        {
+            // Haal alle grocery list items
+            var items = _groceryListItemsRepository.GetAll();
+
+            // Filter op productId indien opgegeven
+            if (productId.HasValue)
+            {
+                items = items.Where(i => i.ProductId == productId.Value).ToList();
+            }
+
+            // Zet om naar BoughtProducts
+            var boughtProducts = items.Select(i =>
+            {
+                var product = _productRepository.Get(i.ProductId);
+                var client = _clientRepository.Get(i.Id);
+                var list = _groceryListRepository.Get(i.Id);
+
+                return new BoughtProducts(client, list, product);
+                
+            }).ToList();
+
+            return boughtProducts;
+        }
     }
 }


### PR DESCRIPTION
# Hotfix aanpassen product aantal
In deze hotfix commits zitten de fix voor het aanpassen van het product in de boodschappenlijsten. Er is nogsteeds een kleine bug waarbij het eerste product aantal wel wordt veranderd maar nog niet aangepast wordt in de ui. De UI update pas als er een ander product van aantal wordt veranderd.